### PR TITLE
Removed regex with separate loop to remove ReDOS vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,16 @@
 'use strict';
 
-var regex = /[^\r\n]/;
-
 module.exports = function (str) {
-	var result = str.match(regex);
-	if (!result) {
+	var firstIndex = 0;
+	while (str[firstIndex] === '\r' || str[firstIndex] === '\n') {
+		firstIndex++;
+	}
+
+	var lastIndex = str.length - 1;
+	if (firstIndex - 1 === lastIndex) {
 		return '';
 	}
-	var firstIndex = result.index;
-	var lastIndex = str.length - 1;
+
 	while (str[lastIndex] === '\r' || str[lastIndex] === '\n') {
 		lastIndex--;
 	}


### PR DESCRIPTION
This PR removed the use of regular expressions to remove Regular Expression Denial Of Service attacks (ReDOS), maintaining a good speed in the worst-case scenario.